### PR TITLE
Use different Nginx versions when deploying to different Heroku stacks (Cedar or Cedar-14)

### DIFF
--- a/heroku-openresty-dev-1.rockspec
+++ b/heroku-openresty-dev-1.rockspec
@@ -19,17 +19,17 @@ build = {
 	type = "command",
 	install_command = [[
 		LIB_DIR=`cd $(PREFIX)/../../../../; pwd`
+		BIN_DIR=`cd $LIB_DIR/../../bin; pwd`
 		cp luajit/lib/libluajit-5.1.so.2.1.0 "$LIB_DIR"
 		(
 			cd "$LIB_DIR"
 			ln -s libluajit-5.1.so.2.1.0 libluajit-5.1.so.2
 			ln -s libluajit-5.1.so.2.1.0 libluajit-5.1.so
 		)
+		cp nginx/sbin/$STACK/nginx "$BIN_DIR"
 	]],
 	install = {
 		bin = {
-			"nginx/sbin/nginx",
-
 			"bin/compile_nginx_config.lua",
 			"bin/start_nginx.sh"
 		},

--- a/heroku-openresty-dev-2.rockspec
+++ b/heroku-openresty-dev-2.rockspec
@@ -1,6 +1,6 @@
 
 package = "heroku-openresty"
-version = "dev-1"
+version = "dev-2"
 
 source = {
 	url = "git://github.com/leafo/heroku-openresty.git"
@@ -19,17 +19,17 @@ build = {
 	type = "command",
 	install_command = [[
 		LIB_DIR=`cd $(PREFIX)/../../../../; pwd`
+		BIN_DIR=`cd $LIB_DIR/../../bin; pwd`
 		cp luajit/lib/libluajit-5.1.so.2.1.0 "$LIB_DIR"
 		(
 			cd "$LIB_DIR"
 			ln -s libluajit-5.1.so.2.1.0 libluajit-5.1.so.2
 			ln -s libluajit-5.1.so.2.1.0 libluajit-5.1.so
 		)
+		cp nginx/sbin/$STACK/nginx "$BIN_DIR"
 	]],
 	install = {
 		bin = {
-			"nginx/sbin/nginx",
-
 			"bin/compile_nginx_config.lua",
 			"bin/start_nginx.sh"
 		},

--- a/heroku-openresty-dev-2.rockspec
+++ b/heroku-openresty-dev-2.rockspec
@@ -20,6 +20,7 @@ build = {
 	install_command = [[
 		LIB_DIR=`cd $(PREFIX)/../../../../; pwd`
 		BIN_DIR=`cd $LIB_DIR/../../bin; pwd`
+		STACK=${STACK:-cedar}
 		cp luajit/lib/libluajit-5.1.so.2.1.0 "$LIB_DIR"
 		(
 			cd "$LIB_DIR"


### PR DESCRIPTION
In Cedar-14, the version of Nginx included here fails. This is because Cedar-14 uses Ubuntu 14.04 which comes with libssl1.0.0 whereas the Nginx binary previously included here had been compiled with libssl0.9.8.

After testing for a while I found that the following shared libraries were missing in order for Nginx to work in Ubuntu 14.04:
- libssl1.0.0
- libcrypto1.0.0
- libc6 (version glibc_2.14)

The Nginx binary version included for Cedar is the previous one 1.5.11.1, which I've left unchanged.
The version included for Cedar-14 is the latest stable of Openresty as of today: 1.7.4.1 
